### PR TITLE
Исправлена циклическая ссылка в Person.h

### DIFF
--- a/include/Person.h
+++ b/include/Person.h
@@ -1,13 +1,16 @@
 #ifndef PERSON_H
 #define PERSON_H
 
-#include <Organization.h>
-#include <PhoneBookItem.h>
+//#include "Organization.h" - циклическая ссылка в h файлах невозможна
+#include "PhoneBookItem.h"
+
+class Organization; //прототип класса - решает проблему циклической ссылки
+
 class Person:PhoneBookItem
 {
     public:
         Person();
-        virtual ~Person();
+        virtual ~Person(); //вообще-то виртуальный деструктор нужно и достаточно сделать в базовом классе
 
         string GetFIO();
         void SetFIO(string val);
@@ -20,7 +23,7 @@ class Person:PhoneBookItem
 
     private:
     string FIO;
-    enum sex;
+    enum sex; //неверно - вначале объявите тип enum (например, enum Sex {male, female};), а здесь объявите поле данного типа
     Organization* organization;
 
 };

--- a/src/Person.cpp
+++ b/src/Person.cpp
@@ -1,5 +1,9 @@
 #include "Person.h"
 
+#include "Organization.h" 
+//мы удалили эту строку из Person.h и я, на всякий случай, её указал в этом файле
+
+//не нужно дублировать содержимое h файла в cpp файле
 class Person:PhoneBookItem
 {
     public:


### PR DESCRIPTION
Исправлена циклическая ссылка в заголовочных файлах - вместо #include "Organization.h" используется class Organization;
исправлен #include<> на  #include"" при подключении заголовочных файлов из проекта

Другие ошибки указаны в комментариях.

В файл Person.cpp скорее всего нужно будет добавить #include "Organization.h" 

Аналогично можно поправить и другие файлы.